### PR TITLE
Decrypt repo on tfstate machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Warning: The cloud-init script gets executed only once, when the GCP instance
          script that need to be applied, use `terraform taint
          google_compute_instance.INSTANCE_NAME` and then `terraform apply`.
          `terraform apply` alone won't work!
+
+2) Prepare a repository on the `tfstate` machine for use with Terraform:
+
+    * Copy the git-crypt key file onto the machine: `gcloud compute scp --project <PROJECT_ID> --zone <ZONE> rchain-sre-git-crypt-key terraform@tfstate:`
+    * SSH onto the machine: `gcloud compute ssh --project <PROJECT_ID> --zone <ZONE> terraform@tfstate`
+    * Decrypt the repository: `cd hardening; git-crypt unlock ~/rchain-sre-git-crypt-key`

--- a/tfstate/cloud-config.yaml.tmpl
+++ b/tfstate/cloud-config.yaml.tmpl
@@ -5,6 +5,7 @@ apt_upgrade: true
 
 packages:
  - unzip
+ - git-crypt
 
 users:
  - name: terraform


### PR DESCRIPTION
Perhaps the process can be simplified in the future by splitting this repo into two:

 * A private, unencrypted one, containing the decryption key: `tfstate` repo
 * A public, partially encrypted, containing everything else: `hardening` repo

There would be fewer manual steps (with copying the key) required.